### PR TITLE
MAS-10-Update README to match permissions in template

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ The following permissions are included in this lighthouse offer.
 | User/Group                                    | Delegated Permission                                 | Access Type | Max Duration | MFA   | Approvers                      |
 | --------------------------------------------- | ---------------------------------------------------- | ----------- | ------------ | ---   | ------------------------------ |
 | ALH - Managed Azure Customer Reliability Engineers                 | Reader                                               | Permanent   | -            | -     | -                              |
+| ALH - Managed Azure Engineers                                      | Reader                                               | Permanent   | -            | -     | -                              |
 | ALH - Managed Azure Customer Reliability Engineers                 | Managed Services Registration Assignment Delete Role | Permanent   | -            | -     | -                              |
+| ALH - Managed Azure Engineers                                      | Managed Services Registration Assignment Delete Role | Permanent   | -            | -     | -                              |
 | ALH - Managed Azure Solutions Design                               | Reader                                               | Permanent   | -            | -     | -                              |
 
 # Deploy to Azure 


### PR DESCRIPTION
Permissions were already updated under previous commit (SSPE-483) however README file table was not updated. Just updating README file to reflect permissions added for support engineers so they could view and remove Fundamentals customer offers as part of offboarding.